### PR TITLE
Enable compression level adjustment

### DIFF
--- a/example/config.yml
+++ b/example/config.yml
@@ -50,6 +50,13 @@ groups:
     ##   bz2: images will be packaged in a tar file with bz2 compression
     compression: xz
 
+    ## Compression level to use for each backup:
+    ## Generally this should be an integer between 1~9 (depends on the
+    ## compression algorithm), where 1 will be the fastest while having
+    ## the lowest compression ratio, and 9 gives the best compression ratio
+    ## but takes the longest time to compress.
+    compression_lvl: 6
+
     ## When doing `virt-backup backup` without specifying any group, only
     ## groups with the autostart option enabled will be backup.
     autostart: True

--- a/virt_backup/backups/pending.py
+++ b/virt_backup/backups/pending.py
@@ -198,9 +198,14 @@ class DomBackup(_BaseDomBackup):
         :param target: directory path that will contain our tar. If not exists,
                        will be created.
         """
+        extra_args = {}
         if self.compression not in (None, "tar"):
             mode = "w:{}".format(self.compression)
             extension = "tar.{}".format(self.compression)
+            if self.compression is "xz":
+                extra_args["preset"] = self.compression_lvl
+            else:
+                extra_args["compresslevel"] = self.compression_lvl
         else:
             mode = "w"
             extension = "tar"
@@ -216,7 +221,7 @@ class DomBackup(_BaseDomBackup):
         )
         if os.path.exists(complete_path):
             raise FileExistsError()
-        return tarfile.open(complete_path, mode)
+        return tarfile.open(complete_path, mode, **extra_args)
 
     def _backup_disk(self, disk, disk_properties, backup_target, definition):
         """


### PR DESCRIPTION
It seems that while the `compression_lvl` configuration is passed into DomBackup, `compression_lvl` were not further given to [`tarfile.open()` in `get_new_tar()`](https://github.com/Anthony25/virt-backup/blob/92de86a3d2067a6b7c95ba28f3ac58408aa21cfd/virt_backup/backups/pending.py#L219), which mean the default compression level is always used during the actual compression.

This pull request makes sure that the `compression_lvl` setting in configuration file will take effect, as well as add `compression_lvl` in the example configuration.


I'm open to changing this PR further (e.g. adding test...though I'm not sure how test for this PR should be written).
Thanks for the awesome repo!